### PR TITLE
sectiontitleの修正

### DIFF
--- a/frontend/src/app/brand/page.tsx
+++ b/frontend/src/app/brand/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import { IMGPATH_BRAND } from '../../lib/common'
-import SectionTtl from '../../components/ui/section-ttl'
+import SectionTitle from '@/components/ui/section-ttl'
 
 export default function Brand() {
     return (
@@ -17,7 +17,7 @@ export default function Brand() {
                 />
             </div>
 
-            <SectionTtl ttl="Catch Copy" sub_ttl="キャッチコピーについて" />
+            <SectionTitle ttl="Catch Copy" sub_ttl="キャッチコピーについて" />
 
             <section
                 id="main_sec"
@@ -64,7 +64,7 @@ export default function Brand() {
                     className=" img_setting"
                 />
             </div>
-            <SectionTtl ttl={'Concept'} sub_ttl={'私達の思い'} />
+            <SectionTitle ttl={'Concept'} sub_ttl={'私達の思い'} />
             <section
                 id="concept_sec"
                 className=" flex justify-between section_setting">
@@ -96,7 +96,7 @@ export default function Brand() {
                     className=" img_setting"
                 />
             </div>
-            <SectionTtl
+            <SectionTitle
                 ttl={'Delegation Message'}
                 sub_ttl={'代表者メッセージ'}
             />

--- a/frontend/src/components/ui/section-ttl.tsx
+++ b/frontend/src/components/ui/section-ttl.tsx
@@ -4,7 +4,7 @@ interface ttlProps {
     ttl: string
     sub_ttl: string
 }
-export default function SectionTtl({ ttl, sub_ttl }) {
+export default function SectionTitle({ ttl, sub_ttl }) {
     return (
         <div
             id="section_ttl"


### PR DESCRIPTION
What:sectionttlの名前をSectionTitleに変更
QA:
<img width="1185" alt="スクリーンショット 2024-11-05 12 43 05" src="https://github.com/user-attachments/assets/c09d95a0-fa74-421c-ad15-6c755a1df9e3">
