### PR TITLE
Fix store header

### DIFF
--- a/frontend/src/components/common/store-header.tsx
+++ b/frontend/src/components/common/store-header.tsx
@@ -12,6 +12,13 @@ import { IMGPATH_HEADER } from '@/lib/common'
 import { notoSansBengali } from '@/lib/fonts'
 
 export default function StoreHeader() {
+    const categoryList = [
+        { categories: 'CATEGORY' },
+        { categories: 'CATEGORY' },
+        { categories: 'CATEGORY' },
+        { categories: 'CATEGORY' },
+    ]
+
     const list_setting =
         'list-none hover:border-b border-black text-center flex-auto'
     return (
@@ -72,18 +79,13 @@ export default function StoreHeader() {
                 </div>
             </div>
             <nav className="flex px-[7.32vw] justify-between font-bold">
-                <li className={`${list_setting} ${notoSansBengali}`}>
-                    CATEGORY
-                </li>
-                <li className={`${list_setting} ${notoSansBengali}`}>
-                    CATEGORY
-                </li>
-                <li className={`${list_setting} ${notoSansBengali}`}>
-                    CATEGORY
-                </li>
-                <li className={`${list_setting} ${notoSansBengali}`}>
-                    CATEGORY
-                </li>
+                {categoryList.map((value, index) => (
+                    <li
+                        key={index}
+                        className={`${list_setting} ${notoSansBengali}`}>
+                        {value.categories}
+                    </li>
+                ))}
             </nav>
         </header>
     )


### PR DESCRIPTION
What:category名をmap関数で展開
QA:
<img width="310" alt="スクリーンショット 2024-11-05 15 59 27" src="https://github.com/user-attachments/assets/8eb22e81-33ac-4845-8f36-a840163d2370">
<img width="468" alt="スクリーンショット 2024-11-05 15 59 37" src="https://github.com/user-attachments/assets/bfccf619-f5f9-4ff4-90b2-9dbf35e1aa3b">
