### PR TITLE
Fix store header

### DIFF
--- a/frontend/src/components/common/store-header.tsx
+++ b/frontend/src/components/common/store-header.tsx
@@ -4,12 +4,13 @@ import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons'
 import { faHeart } from '@fortawesome/free-regular-svg-icons'
 import { faUser } from '@fortawesome/free-solid-svg-icons'
 import { faCartShopping } from '@fortawesome/free-solid-svg-icons'
-import { config } from '@fortawesome/fontawesome-svg-core'
+import { config, IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
 config.autoAddCss = false
 import Image from 'next/image'
 import { IMGPATH_HEADER } from '@/lib/common'
 import { notoSansBengali } from '@/lib/fonts'
+import { link } from 'fs'
 
 export default function StoreHeader() {
     const categoryList = [
@@ -17,6 +18,16 @@ export default function StoreHeader() {
         { categories: 'CATEGORY' },
         { categories: 'CATEGORY' },
         { categories: 'CATEGORY' },
+    ]
+
+    const iconList: {
+        link: string
+        iconName: IconDefinition
+        color: string
+    }[] = [
+        { link: '/favorites', iconName: faHeart, color: '#db3f3f' },
+        { link: '/mypage', iconName: faUser, color: '#CED4DA' },
+        { link: '/carts', iconName: faCartShopping, color: '#CED4DA' },
     ]
 
     const list_setting =
@@ -55,27 +66,15 @@ export default function StoreHeader() {
                     </div>
                 </div>
                 <div id="right-block" className="flex gap-[2.2vw] items-center">
-                    <Link href="/favorites">
-                        <FontAwesomeIcon
-                            icon={faHeart}
-                            size="xl"
-                            color="#db3f3f"
-                        />
-                    </Link>
-                    <Link href="/mypage">
-                        <FontAwesomeIcon
-                            icon={faUser}
-                            size="xl"
-                            color="#CED4DA"
-                        />
-                    </Link>
-                    <Link href="/carts">
-                        <FontAwesomeIcon
-                            icon={faCartShopping}
-                            size="xl"
-                            color="#CED4DA"
-                        />
-                    </Link>
+                    {iconList.map((value, index) => (
+                        <Link href={value.link} key={index}>
+                            <FontAwesomeIcon
+                                icon={value.iconName}
+                                size="xl"
+                                color={value.color}
+                            />
+                        </Link>
+                    ))}
                 </div>
             </div>
             <nav className="flex px-[7.32vw] justify-between font-bold">


### PR DESCRIPTION
What:iconをmap関数で展開
QA:
<img width="521" alt="スクリーンショット 2024-11-05 16 18 03" src="https://github.com/user-attachments/assets/9db1af1b-02b1-4f48-861f-5a7b34857080">
<img width="345" alt="スクリーンショット 2024-11-05 16 18 18" src="https://github.com/user-attachments/assets/bea2df36-de60-44b0-8512-77f5f9a753da">
