### PR TITLE
ストアヘッダーのレスポンシブ対応とfluidプラグインの挿入

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "eslint": "^8.27.0",
         "eslint-config-next": "^14.0.3",
         "eslint-config-prettier": "^7.2.0",
+        "fluid-tailwind": "^1.0.3",
         "postcss": "^8.4.6",
         "prettier": "^3.2.5",
         "tailwindcss": "^3.4.3"
@@ -2764,6 +2765,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2799,6 +2812,20 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/fluid-tailwind": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fluid-tailwind/-/fluid-tailwind-1.0.3.tgz",
+      "integrity": "sha512-JhSklHiXUcKnb/PIru1TbyorLD+k0rCIgeAbFwzu1QyQHYDKmKKsKzN7xPisSeGGr7FtYY9S63t+tzddUlxxrQ==",
+      "dev": true,
+      "dependencies": {
+        "filter-obj": "^5.1.0",
+        "map-obj": "^5.0.2",
+        "picocolors": "^1.0.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.2.0"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -3839,6 +3866,18 @@
       "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.2.tgz",
+      "integrity": "sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -7646,6 +7685,12 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "dev": true
+    },
     "find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -7672,6 +7717,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "fluid-tailwind": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fluid-tailwind/-/fluid-tailwind-1.0.3.tgz",
+      "integrity": "sha512-JhSklHiXUcKnb/PIru1TbyorLD+k0rCIgeAbFwzu1QyQHYDKmKKsKzN7xPisSeGGr7FtYY9S63t+tzddUlxxrQ==",
+      "dev": true,
+      "requires": {
+        "filter-obj": "^5.1.0",
+        "map-obj": "^5.0.2",
+        "picocolors": "^1.0.0"
+      }
     },
     "follow-redirects": {
       "version": "1.15.9",
@@ -8380,6 +8436,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "map-obj": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.2.tgz",
+      "integrity": "sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "eslint": "^8.27.0",
     "eslint-config-next": "^14.0.3",
     "eslint-config-prettier": "^7.2.0",
+    "fluid-tailwind": "^1.0.3",
     "postcss": "^8.4.6",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.3"

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -18,7 +18,9 @@ export default function RootLayout({
 }) {
     return (
         <html lang="ja">
-            <body className={notoSansJp.className}>{children}</body>
+            <body className={`${notoSansJp.className} text-base`}>
+                {children}
+            </body>
         </html>
     )
 }

--- a/frontend/src/components/common/store-header.tsx
+++ b/frontend/src/components/common/store-header.tsx
@@ -10,12 +10,16 @@ config.autoAddCss = false
 import Image from 'next/image'
 import { IMGPATH_HEADER } from '@/lib/common'
 import { notoSansBengali } from '@/lib/fonts'
-import { link } from 'fs'
 
 export default function StoreHeader() {
     const categoryList = [
         { categories: 'CATEGORY' },
         { categories: 'CATEGORY' },
+        { categories: 'CATEGORY' },
+        { categories: 'CATEGORY' },
+    ]
+
+    const categoryListSp = [
         { categories: 'CATEGORY' },
         { categories: 'CATEGORY' },
     ]
@@ -31,15 +35,28 @@ export default function StoreHeader() {
     ]
 
     const list_setting =
-        'list-none hover:border-b border-black text-center flex-auto'
+        'list-none hover:border-b border-black text-center flex-auto ~text-sm/base'
     return (
-        <header className="flex-col flex gap-5">
-            <div id="head-top-cnt" className="flex justify-between px-[7.32vw]">
+        <>
+            <header id="header_sp" className=" lg:hidden">
                 <div
-                    id="left-block"
-                    className="flex justify-between gap-[2.928vw] items-center hover:justify-center">
+                    id="top_cnt"
+                    className=" flex items-center px-5 justify-between">
+                    <div id="icon_block" className="flex gap-4 items-center">
+                        {iconList.map((value, index) => (
+                            <Link href={value.link} key={index}>
+                                <FontAwesomeIcon
+                                    icon={value.iconName}
+                                    color={value.color}
+                                    className=" text-xl md:text-2xl"
+                                />
+                            </Link>
+                        ))}
+                    </div>
                     <Link href="/">
-                        <div id="ec-dent-logo" className=" w-[21.96vw] h-auto">
+                        <div
+                            id="ec-dent-logo"
+                            className=" w-[37.5vw] h-auto max-[300px]:">
                             <Image
                                 src={`${IMGPATH_HEADER}ec-dent-logo.svg`}
                                 alt=""
@@ -49,10 +66,19 @@ export default function StoreHeader() {
                             />
                         </div>
                     </Link>
-
                     <div
-                        id="search-items"
-                        className="border-b border-black py-1 h-fit flex items-center">
+                        id="hamburger"
+                        className=" w-[40px] h-[40px] flex flex-col gap-1 justify-center items-center border border-black rounded-[50%] ml-12">
+                        <span className=" w-5 h-[1px] bg-black"></span>
+                        <span className=" w-5 h-[1px] bg-black"></span>
+                        <span className=" w-5 h-[1px] bg-black"></span>
+                    </div>
+                </div>
+
+                <div id="search_block" className=" px-5 mx-5">
+                    <div
+                        id="search_items"
+                        className="border-b border-black py-1 h-fit flex items-center pt-7">
                         <FontAwesomeIcon
                             icon={faMagnifyingGlass}
                             size="lg"
@@ -61,31 +87,81 @@ export default function StoreHeader() {
                         <input
                             type="text"
                             placeholder="すべての商品から探す"
-                            className="border-none pl-[1.098vw] w-fit p-0 font-bold text-black opacity-35 focus:border-none focus:ring-2 focus:ring-[#5CCEA7] rounded-lg"
+                            className="border-none pl-[1.098vw] w-full p-0 font-bold text-black opacity-35 focus:border-none focus:ring-2 focus:ring-[#5CCEA7] rounded-lg placeholder:text-lg/xl"
                         />
                     </div>
                 </div>
-                <div id="right-block" className="flex gap-[2.2vw] items-center">
-                    {iconList.map((value, index) => (
-                        <Link href={value.link} key={index}>
-                            <FontAwesomeIcon
-                                icon={value.iconName}
-                                size="xl"
-                                color={value.color}
-                            />
-                        </Link>
+                <nav className="flex pt-7 justify-between font-bold">
+                    {categoryListSp.map((value, index) => (
+                        <li
+                            key={index}
+                            className={`${list_setting} ${notoSansBengali.className}`}>
+                            {value.categories}
+                        </li>
                     ))}
+                </nav>
+            </header>
+
+            <header className="flex-col gap-5 lg:flex sp:hidden">
+                <div
+                    id="head-top-cnt"
+                    className="flex justify-between px-[7.32vw]">
+                    <div
+                        id="left-block"
+                        className="flex justify-between gap-[2.928vw] items-center hover:justify-center">
+                        <Link href="/">
+                            <div
+                                id="ec-dent-logo"
+                                className=" w-[21.96vw] h-auto max-[300px]:">
+                                <Image
+                                    src={`${IMGPATH_HEADER}ec-dent-logo.svg`}
+                                    alt=""
+                                    width={500}
+                                    height={500}
+                                    className=" img_setting"
+                                />
+                            </div>
+                        </Link>
+
+                        <div
+                            id="search-items"
+                            className="border-b border-black py-1 h-fit flex items-center">
+                            <FontAwesomeIcon
+                                icon={faMagnifyingGlass}
+                                size="lg"
+                                color="#333333b3"
+                            />
+                            <input
+                                type="text"
+                                placeholder="すべての商品から探す"
+                                className="border-none pl-[1.098vw] w-fit p-0 font-bold text-black opacity-35 focus:border-none focus:ring-2 focus:ring-[#5CCEA7] rounded-lg placeholder:~text-base/lg"
+                            />
+                        </div>
+                    </div>
+                    <div
+                        id="right-block"
+                        className="flex gap-[2.2vw] items-center">
+                        {iconList.map((value, index) => (
+                            <Link href={value.link} key={index}>
+                                <FontAwesomeIcon
+                                    icon={value.iconName}
+                                    size="xl"
+                                    color={value.color}
+                                />
+                            </Link>
+                        ))}
+                    </div>
                 </div>
-            </div>
-            <nav className="flex px-[7.32vw] justify-between font-bold">
-                {categoryList.map((value, index) => (
-                    <li
-                        key={index}
-                        className={`${list_setting} ${notoSansBengali}`}>
-                        {value.categories}
-                    </li>
-                ))}
-            </nav>
-        </header>
+                <nav className="flex px-[7.32vw] justify-between font-bold">
+                    {categoryList.map((value, index) => (
+                        <li
+                            key={index}
+                            className={`${list_setting} ${notoSansBengali}`}>
+                            {value.categories}
+                        </li>
+                    ))}
+                </nav>
+            </header>
+        </>
     )
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,9 +1,24 @@
+import fluid, { extract, screens, fontSize } from 'fluid-tailwind'
+
 const plugin = require('tailwindcss/plugin')
 
 module.exports = {
-    content: ['./src/**/*.{js,jsx,ts,tsx}'],
-    theme: {},
+    content: {
+        files: ['./src/**/*.{js,jsx,ts,tsx}'],
+        extract,
+    },
+    theme: {
+        screens,
+        screens: {
+            sp: '360px',
+            md: '768px',
+            lg: '1024px',
+            xl: '1366px',
+        },
+        fontSize,
+    },
     plugins: [
+        fluid,
         require('@tailwindcss/forms'),
         plugin(function ({ addComponents }) {
             addComponents({


### PR DESCRIPTION
Waht：ストアヘッダーのレスポンシブ対応（ハンバーガーメニュー未実装）とプラグインのインストールとブレイクポイントの定義、bodyのテキストサイズを16pxに統一
QA：
![480](https://github.com/user-attachments/assets/6be416d7-9e68-449e-bb14-35e8e5205cfc)
![768](https://github.com/user-attachments/assets/5efcb738-9298-46ee-a289-4d1859fd2e56)
![1024](https://github.com/user-attachments/assets/abe901b8-3ec4-48e5-bc21-36b15e5c656f)
![1366](https://github.com/user-attachments/assets/5a44a8dd-3be3-4c34-ada1-231dd1379361)
