### PR TITLE
360px時点のレイアウト崩れの修正完了

### DIFF
--- a/frontend/src/app/brand/page.tsx
+++ b/frontend/src/app/brand/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { IMGPATH_BRAND } from '../../lib/common'
+import { IMGPATH_BRAND } from '@/lib/common'
 import SectionTitle from '@/components/ui/section-ttl'
 import StoreHeader from '@/components/common/store-header'
 import { dmSerifDisplay, shipporiMincho } from '@/lib/fonts'
@@ -160,7 +160,7 @@ export default function Brand() {
                     </div>
                 </section>
             </main>
-            {/* <Footer /> */}
+            <Footer />
         </>
     )
 }

--- a/frontend/src/components/common/footer.tsx
+++ b/frontend/src/components/common/footer.tsx
@@ -32,7 +32,7 @@ export default function Footer() {
             <div
                 id="footer_top_cnt"
                 className=" items-center py-5 flex-col flex  gap-5 bg-[#5ccea780] 
-                md:pl-12 md:items-start md:flex-row md:gap-10 
+                md:pl-12 md:items-start md:flex-row md:gap-14.5
                 lg:gap-16 lg:items-start 
                 xl:pl-[5.12445vw] xl:gap-[7.8330vw]">
                 <Link href="">
@@ -47,10 +47,10 @@ export default function Footer() {
                 </Link>
                 <nav
                     id="footer_block"
-                    className=" flex-col flex gap-5 px-5 text-center md:flex-row md:px-0 lg:gap-10 xl:gap-[3.80vw] ">
+                    className=" flex-col flex gap-5 px-5 text-center md:flex-row md:px-0 md:gap-14.5 lg:gap-10 xl:gap-[3.80vw] ">
                     <div
                         id="left_items"
-                        className=" flex gap-2 justify-center  md:flex-col md:text-left xl:flex xl:gap-0">
+                        className=" flex gap-4 justify-center flex-wrap md:flex-col md:gap-2 md:text-left xl:flex xl:gap-0">
                         {leftItems.map((item: LeftItems) => (
                             <Link
                                 key={item.text}


### PR DESCRIPTION
# What:何を修正したのか
フッターのメニューの修正とgapの修正
# Why：なぜ修正したのか
360px時点での画面からメニューがはみ出していたため
### 修正前画像
![スクリーンショット 2024-12-03 17 15 48](https://github.com/user-attachments/assets/f3c7c853-2930-45ab-a199-18b73e1e35f4)

# QA:どのようなものを修正したのか
![スクリーンショット 2024-12-03 17 14 34](https://github.com/user-attachments/assets/66a9c83f-88dc-455a-adc6-90f6d84a6d7e)
